### PR TITLE
Fix failure message in haveHeader

### DIFF
--- a/src/commonMain/kotlin/io/kotest/assertions/ktor/client/response.kt
+++ b/src/commonMain/kotlin/io/kotest/assertions/ktor/client/response.kt
@@ -67,8 +67,8 @@ fun haveHeader(headerName: String, headerValue: String) = object : Matcher<HttpR
    override fun test(value: HttpResponse): MatcherResult {
       return MatcherResult(
          value.headers[headerName] == headerValue,
-         { "Response should have header $headerName=$value but $headerName=${value.headers[headerName]}" },
-         { "Response should not have header $headerName=$value" },
+         { "Response should have header $headerName=$headerValue but $headerName=${value.headers[headerName]}" },
+         { "Response should not have header $headerName=$headerValue" },
       )
    }
 }


### PR DESCRIPTION
Fix failure message in `src/commonMain/kotlin/io/kotest/assertions/ktor/client/response.kt` haveHeader function to match  
`src/jvmMain/kotlin/io/kotest/assertions/ktor/testApp.kt` haveHeader function.

See also #2 