### PR TITLE
Add assertions for header presence without checking for a specific value

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,6 +86,7 @@ kotlin {
          dependsOn(jvmMain)
          dependencies {
             implementation(Libs.Kotest.junit5)
+            implementation(Libs.Kotest.datatest)
          }
       }
 
@@ -136,7 +137,7 @@ kotlin {
       val iosArm32Main by getting {
          dependsOn(desktopMain)
       }
-      
+
       val iosSimulatorArm64Main by getting {
          dependsOn(desktopMain)
       }

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -8,6 +8,7 @@ object Libs {
       private const val version = "5.8.1"
       const val assertionsShared = "io.kotest:kotest-assertions-shared:$version"
       const val api = "io.kotest:kotest-framework-api:$version"
+      const val datatest = "io.kotest:kotest-framework-datatest:$version"
       const val junit5 = "io.kotest:kotest-runner-junit5-jvm:$version"
    }
 

--- a/src/commonMain/kotlin/io/kotest/assertions/ktor/client/response.kt
+++ b/src/commonMain/kotlin/io/kotest/assertions/ktor/client/response.kt
@@ -4,50 +4,37 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
-import io.ktor.client.statement.HttpResponse
-import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpProtocolVersion
-import io.ktor.http.contentType
+import io.ktor.client.statement.*
+import io.ktor.http.*
 
-infix fun HttpResponse.shouldHaveETag(etag: String) = this should haveETag(etag)
-infix fun HttpResponse.shouldNotHaveETag(etag: String) = this shouldNot haveETag(etag)
-fun haveETag(expected: String) = object : Matcher<HttpResponse> {
-   override fun test(value: HttpResponse): MatcherResult {
-      val actual = value.headers[HttpHeaders.ETag]
-      return MatcherResult(
-         actual == expected,
-         { "Response should have ETag $expected but had $actual." },
-         { "Response should not have ETag $expected." },
-      )
-   }
-}
+infix fun HttpResponse.shouldHaveETag(etag: String) = this should haveHeader(HttpHeaders.ETag, etag)
+fun HttpResponse.shouldHaveETag() = this should haveHeader(HttpHeaders.ETag)
+infix fun HttpResponse.shouldNotHaveETag(etag: String) = this shouldNot haveHeader(HttpHeaders.ETag, etag)
+fun HttpResponse.shouldNotHaveETag() = this shouldNot haveHeader(HttpHeaders.ETag)
 
-infix fun HttpResponse.shouldHaveCacheControl(cacheControl: String) = this should haveCacheControl(cacheControl)
-infix fun HttpResponse.shouldNotCacheControl(cacheControl: String) = this shouldNot haveCacheControl(cacheControl)
-fun haveCacheControl(expected: String) = object : Matcher<HttpResponse> {
-   override fun test(value: HttpResponse): MatcherResult {
-      val actual = value.headers[HttpHeaders.CacheControl]
-      return MatcherResult(
-         actual == expected,
-         { "Response should have Cache-Control: $expected but had: ${actual}." },
-         { "Response should not have Cache-Control $expected." },
-      )
-   }
-}
+infix fun HttpResponse.shouldHaveCacheControl(cacheControl: String) =
+   this should haveHeader(HttpHeaders.CacheControl, cacheControl)
 
-infix fun HttpResponse.shouldHaveContentEncoding(encoding: String) = this should haveContentEncoding(encoding)
-infix fun HttpResponse.shouldNotHaveContentEncoding(encoding: String) = this shouldNot haveContentEncoding(encoding)
-fun haveContentEncoding(expected: String) = object : Matcher<HttpResponse> {
-   override fun test(value: HttpResponse): MatcherResult {
-      val actual = value.headers[HttpHeaders.ContentEncoding]
-      return MatcherResult(
-         actual == expected,
-         { "Response should have Content-Encoding: $expected but had: ${actual}." },
-         { "Response should not have Content-Encoding $expected." },
-      )
-   }
-}
+fun HttpResponse.shouldHaveCacheControl() = this should haveHeader(HttpHeaders.CacheControl)
+infix fun HttpResponse.shouldNotHaveCacheControl(cacheControl: String) =
+   this shouldNot haveHeader(HttpHeaders.CacheControl, cacheControl)
+
+
+fun HttpResponse.shouldNotHaveCacheControl() = this shouldNot haveHeader(HttpHeaders.CacheControl)
+infix fun HttpResponse.shouldHaveContentEncoding(encoding: String) =
+   this should haveHeader(HttpHeaders.ContentEncoding, encoding)
+
+fun HttpResponse.shouldHaveContentEncoding() = this should haveHeader(HttpHeaders.ContentEncoding)
+
+infix fun HttpResponse.shouldNotHaveContentEncoding(encoding: String) =
+   this shouldNot haveHeader(HttpHeaders.ContentEncoding, encoding)
+
+fun HttpResponse.shouldNotHaveContentEncoding() = this shouldNot haveHeader(HttpHeaders.ContentEncoding)
+
+infix fun HttpResponse.shouldHaveHeader(name: String) = this should haveHeader(name)
+fun HttpResponse.shouldHaveHeader(name: String, value: String) = this should haveHeader(name, value)
+infix fun HttpResponse.shouldNotHaveHeader(name: String) = this shouldNot haveHeader(name)
+fun HttpResponse.shouldNotHaveHeader(name: String, value: String) = this shouldNot haveHeader(name, value)
 
 infix fun HttpResponse.shouldHaveVersion(version: HttpProtocolVersion) = this should haveVersion(version)
 infix fun HttpResponse.shouldNotHaveVersion(version: HttpProtocolVersion) = this shouldNot haveVersion(version)
@@ -55,20 +42,8 @@ fun haveVersion(version: HttpProtocolVersion) = object : Matcher<HttpResponse> {
    override fun test(value: HttpResponse): MatcherResult {
       return MatcherResult(
          value.version == version,
-         { "Response should have version $version but had version ${value.version}" },
+         { "Response should have version $version but was ${value.version}" },
          { "Response should not have version $version" },
-      )
-   }
-}
-
-fun HttpResponse.shouldHaveHeader(name: String, value: String) = this should haveHeader(name, value)
-fun HttpResponse.shouldNotHaveHeader(name: String, value: String) = this shouldNot haveHeader(name, value)
-fun haveHeader(headerName: String, headerValue: String) = object : Matcher<HttpResponse> {
-   override fun test(value: HttpResponse): MatcherResult {
-      return MatcherResult(
-         value.headers[headerName] == headerValue,
-         { "Response should have header $headerName=$value but $headerName=${value.headers[headerName]}" },
-         { "Response should not have header $headerName=$value" },
       )
    }
 }
@@ -79,8 +54,28 @@ fun haveContentType(contentType: ContentType) = object : Matcher<HttpResponse> {
    override fun test(value: HttpResponse): MatcherResult {
       return MatcherResult(
          value.contentType() == contentType,
-         { "Response should have ContentType $contentType= but was ${value.contentType()}" },
-         { "Response should not have ContentType $contentType" },
+         { "Response should have Content-Type $contentType but was ${value.contentType()}." },
+         { "Response should not have Content-Type $contentType." },
       )
    }
 }
+
+fun haveHeader(headerName: String) = object : Matcher<HttpResponse> {
+   override fun test(value: HttpResponse): MatcherResult = MatcherResult(
+      value.headers.contains(headerName),
+      { "Response should have $headerName header set." },
+      { "Response should not have $headerName header set." },
+   )
+}
+
+fun haveHeader(headerName: String, headerValue: String) = object : Matcher<HttpResponse> {
+   override fun test(value: HttpResponse): MatcherResult {
+      val actual = value.headers[headerName]
+      return MatcherResult(
+         actual == headerValue,
+         { "Response should have $headerName: $headerValue but had: $actual" },
+         { "Response should not have $headerName: $headerValue." },
+      )
+   }
+}
+

--- a/src/jvmTest/kotlin/io/kotest/assertions/ktor/client/ResponseKtTest.kt
+++ b/src/jvmTest/kotlin/io/kotest/assertions/ktor/client/ResponseKtTest.kt
@@ -1,0 +1,152 @@
+package io.kotest.assertions.ktor.client
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import kotlin.reflect.KFunction1
+import kotlin.reflect.KFunction2
+
+data class HeaderTest(
+   val headerName: String,
+   val headerValue: String,
+   val shouldExist: KFunction1<HttpResponse, Unit>,
+   val shouldNotExist: KFunction1<HttpResponse, Unit>,
+   val shouldHaveValue: KFunction2<HttpResponse, String, Unit>,
+   val shouldNotHaveValue: KFunction2<HttpResponse, String, Unit>
+)
+
+class ResponseKtTest : StringSpec({
+   withData(
+      nameFn = { "Header test: ${it.headerName}" },
+      HeaderTest(
+         HttpHeaders.ETag,
+         "some-etag-hash",
+         HttpResponse::shouldHaveETag,
+         HttpResponse::shouldNotHaveETag,
+         HttpResponse::shouldHaveETag,
+         HttpResponse::shouldNotHaveETag
+      ),
+      HeaderTest(
+         HttpHeaders.CacheControl, "some-cache-control",
+         HttpResponse::shouldHaveCacheControl,
+         HttpResponse::shouldNotHaveCacheControl,
+         HttpResponse::shouldHaveCacheControl,
+         HttpResponse::shouldNotHaveCacheControl,
+      ),
+      HeaderTest(
+         HttpHeaders.ContentEncoding, "UTF-8",
+         HttpResponse::shouldHaveContentEncoding,
+         HttpResponse::shouldNotHaveContentEncoding,
+         HttpResponse::shouldHaveContentEncoding,
+         HttpResponse::shouldNotHaveContentEncoding,
+      )
+   ) { (headerName, headerValue, shouldExist, shouldNotExist, shouldHaveValue, shouldNotHaveValue) ->
+      testApplication {
+         routing {
+            get("/withHeader") {
+               call.response.header(headerName, headerValue)
+               call.respondText("with $headerName")
+            }
+            get("/withoutHeader") {
+               call.respondText("without $headerName")
+            }
+         }
+
+         client.get("/withoutHeader").apply {
+            // Failure match for header without value
+            shouldThrow<AssertionError> {
+               shouldExist(this)
+            }.message shouldBe "Response should have $headerName header set."
+
+            // Success not match for header without value
+            shouldNotExist(this)
+         }
+
+         client.get("/withHeader").apply {
+            // Success match for header without value
+            shouldExist(this)
+
+            // Success match for header with value
+            shouldHaveValue(this, headerValue)
+
+            // Failure match for header with value
+            shouldThrow<AssertionError> {
+               shouldHaveValue(this, "otherValue")
+            }.message shouldBe "Response should have $headerName: otherValue but had: $headerValue"
+
+            // Failure not match for header without value
+            shouldThrow<AssertionError> {
+               shouldNotExist(this)
+            }.message shouldBe "Response should not have $headerName header set."
+
+            // Success not match for header with value
+            shouldNotHaveValue(this, "otherValue")
+
+            // Failure not match for header with value
+            shouldThrow<AssertionError> {
+               shouldNotHaveValue(this, headerValue)
+            }.message shouldBe "Response should not have $headerName: $headerValue."
+         }
+      }
+   }
+
+   "For any custom header" {
+      val customName = "X-Custom"
+      val customValue = "custom"
+      testApplication {
+         routing {
+            get("/with") {
+               call.response.header(customName, customValue)
+               call.respondText("ok")
+            }
+            get("/without") {
+               call.respondText("ok")
+            }
+         }
+         client.get("/with").shouldHaveHeader(customName)
+         client.get("/with").shouldHaveHeader(customName, customValue)
+         client.get("/with").shouldNotHaveHeader(customName, "anotherValue")
+         client.get("/without").shouldNotHaveHeader(customName)
+      }
+   }
+
+   "HttpVersion assertions" {
+      testApplication {
+         routing { get("/") { call.respondText("ok") } }
+         client.get("/").apply {
+            shouldHaveVersion(HttpProtocolVersion.HTTP_1_1)
+            shouldNotHaveVersion(HttpProtocolVersion.HTTP_2_0)
+            shouldThrow<AssertionError> {
+               shouldNotHaveVersion(HttpProtocolVersion.HTTP_1_1)
+            }.message shouldBe "Response should not have version HTTP/1.1"
+            shouldThrow<AssertionError> {
+               shouldHaveVersion(HttpProtocolVersion.HTTP_2_0)
+            }.message shouldBe "Response should have version HTTP/2.0 but was HTTP/1.1"
+         }
+      }
+   }
+
+   "ContentType assertions" {
+      testApplication {
+         routing { get("/") { call.respondText("ok") } }
+         client.get("/").apply {
+            shouldHaveContentType(ContentType.Text.Plain.withParameter("charset", "UTF-8"))
+            shouldNotHaveContentType(ContentType.Application.GZip)
+            shouldThrow<AssertionError> {
+               shouldNotHaveContentType(ContentType.Text.Plain.withParameter("charset", "UTF-8"))
+            }.message shouldBe "Response should not have Content-Type text/plain; charset=UTF-8."
+            shouldThrow<AssertionError> {
+               shouldHaveContentType(ContentType.Application.GZip)
+            }.message shouldBe "Response should have Content-Type application/gzip but was text/plain; charset=UTF-8."
+         }
+      }
+   }
+})


### PR DESCRIPTION
Also, while I was in the code:

* write tests for the commonMain source set using the new
  testApplication{} syntax from KTor.
* Factor common code in matchers and in tests
* Write tests for Version and ContentType matchers in commonMain.
