### PR TITLE
Update kotlin to 1.9.25

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,124 +32,61 @@ group = "io.kotest.extensions"
 version = Ci.version
 
 kotlin {
-
-   targets {
-
-      jvm {
-         compilations.all {
-            kotlinOptions {
-               jvmTarget = "1.8"
-            }
+   jvm {
+      compilations.all {
+         kotlinOptions {
+            jvmTarget = "1.8"
          }
       }
-
-      js(IR) {
-         browser()
-         nodejs()
-      }
-
-      linuxX64()
-
-      mingwX64()
-
-      watchosX64()
-      watchosX86()
-      watchosArm32()
-      watchosArm64()
-
-      macosArm64()
-      macosX64()
-      tvos()
-
-      iosX64()
-      iosArm64()
-      iosArm32()
-      iosSimulatorArm64()
    }
 
-   sourceSets {
+   js(IR) {
+      browser()
+      nodejs()
+   }
 
-      val commonMain by getting {
+   linuxX64()
+
+   mingwX64()
+
+   watchosX64()
+   watchosArm32()
+   watchosArm64()
+
+   macosArm64()
+   macosX64()
+   tvosX64()
+   tvosArm64()
+   tvosSimulatorArm64()
+
+   iosX64()
+   iosArm64()
+   iosSimulatorArm64()
+
+   sourceSets {
+      commonMain {
          dependencies {
             implementation(libs.kotest.assertionsShared)
             implementation(libs.ktorClient.core)
          }
       }
 
-      val jvmMain by getting {
-         dependsOn(commonMain)
+      jvmMain {
          dependencies {
             implementation(libs.ktorServer.core)
             implementation(libs.ktorServer.testHost)
          }
       }
 
-      val jvmTest by getting {
-         dependsOn(jvmMain)
+      jvmTest {
          dependencies {
             implementation(libs.kotest.runnerJunit5)
          }
       }
-
-      val desktopMain by creating {
-         dependsOn(commonMain)
-      }
-
-      val watchosX86Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val watchosX64Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val watchosArm32Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val watchosArm64Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val macosArm64Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val macosX64Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val mingwX64Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val linuxX64Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val iosX64Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val iosArm64Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val iosArm32Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val iosSimulatorArm64Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val tvosMain by getting {
-         dependsOn(desktopMain)
-      }
    }
 }
 
-tasks.named<Test>("jvmTest") {
+tasks.named<Test>("jvmTest").configure {
    useJUnitPlatform()
    filter {
       isFailOnNoMatchingTests = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.8.23"
+kotlin = "1.9.25"
 kotest = "5.8.1"
 ktor = "2.3.10"
 dokka = "0.10.1"


### PR DESCRIPTION
The current `master` state is not building:

```
* What went wrong:
Plugin [id: 'org.jetbrains.kotlin.multiplatform', version: '1.8.23'] was not found in any of the following sources:

- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Included Builds (No included builds contain this plugin)
- Plugin Repositories (could not resolve plugin artifact 'org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:1.8.23')
  Searched in the following repositories:
    Gradle Central Plugin Repository
```

It seems like the 1.8.32 version of the mutliplatform-plugin has disappeared from central repositories.

To go a step forward, I update it to the latest 1.9.x release (after aligning with @Kantis about to which version to update to).